### PR TITLE
add confd-client dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,6 +39,7 @@ Depends:
     wazo-dird-phoned,
     wazo-libsccp,
     wazo-plugind,
+    wazo-confd-client-python3,
     wazo-plugind-client-python3,
     wazo-provd-client-python3,
     wazo-service,


### PR DESCRIPTION
reason: wazo-upgrade use it in post-start scripts